### PR TITLE
Make forms of "read" consistent to other verbs

### DIFF
--- a/list.json
+++ b/list.json
@@ -412,8 +412,8 @@
         },
         {
             "infinitive": "read",
-            "past_simple": "read,/red/",
-            "past_participle": "read /red/"
+            "past_simple": "read/red",
+            "past_participle": "read/red"
         },
         {
             "infinitive": "ride",


### PR DESCRIPTION
Hi! I've noticed that forms of "read" verb are written in inconsistent way. This PR fixes it